### PR TITLE
CSS class preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist/
 /.vscode/
 .DS_Store
+.idea

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,7 @@
+.container {
+  background-color: gray;
+}
+
+.m1 { margin: 0.1rem; }
+.m2 { margin: 0.25rem; }
+.m3 { margin: 0.5rem; }

--- a/src/CodeMirror6.svelte
+++ b/src/CodeMirror6.svelte
@@ -11,6 +11,16 @@
 
   let element
 
+  const styles = `.container {
+  display: block;
+  width: 100%;
+}
+main { color: red; }
+
+.m1 { margin: 0.1rem; }
+.m2 { margin: 0.25rem; }
+.m3 { margin: 0.5rem; }`
+
   let view
   onMount(() => {
     const language = new Compartment
@@ -21,7 +31,14 @@
         basicSetup,
         // language.of(css()),
         language.of(html()),
-        cssPeek(),
+        cssPeek({
+          src: [
+            '/style.css',
+          ],
+          cssContent: [
+            styles,
+          ]
+        }),
         emmetExt({
           config: {
             type: 'html',

--- a/src/CodeMirror6.svelte
+++ b/src/CodeMirror6.svelte
@@ -6,7 +6,8 @@
   import {basicSetup} from "@codemirror/basic-setup"
   import {css} from "@codemirror/lang-css"
   import { html } from '@codemirror/lang-html';
-  import emmetExt from './emmet-codemirror-ext'
+  import emmetExt from './emmet-codemirror-ext';
+  import cssPeek from './css-peek';
 
   let element
 
@@ -15,16 +16,17 @@
     const language = new Compartment
 
     const state = EditorState.create({
-      doc: "h1 {\n\t\n}",
+      doc: "<main id=\"app\" class=\"container m3 p5\"></main>",
       extensions: [
         basicSetup,
-        language.of(css()),
-        // language.of(html()),
+        // language.of(css()),
+        language.of(html()),
+        cssPeek(),
         emmetExt({
           config: {
-            type: 'stylesheet',
-            syntax: 'css'
-          }
+            type: 'html',
+            syntax: 'html'
+          },
         }),
         keymap.of([
           defaultTabBinding

--- a/src/css-peek.ts
+++ b/src/css-peek.ts
@@ -1,0 +1,57 @@
+import {EditorView} from "@codemirror/basic-setup"
+import {StateField, EditorState} from "@codemirror/state"
+import {keymap} from "@codemirror/view"
+import {Tooltip, hoverTooltip} from "@codemirror/tooltip"
+
+const lookupCssClass = (className) => {
+  return className;
+}
+const isInAttribute = (attr, line, start, end) => {
+  const regex = new RegExp( attr + '=[\'"]([\\w ]*?)[\'"]', 'gm');
+  let m;
+
+  while ((m = regex.exec(line)) !== null) {
+    // This is necessary to avoid infinite loops with zero-width matches
+    if (m.index === regex.lastIndex) {
+      regex.lastIndex++;
+    }
+
+    const matchStart = m.index + attr.length + 2;
+    const matchEnd = m.index + m[0].length - 1;
+    if (start >= matchStart && end <= matchEnd) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export const wordHover = hoverTooltip((view, pos, side) => {
+  let {from, to, text} = view.state.doc.lineAt(pos)
+  let start = pos, end = pos
+  while (start > from && /\w/.test(text[start - from - 1])) start--
+  while (end < to && /\w/.test(text[end - from])) end++
+  if (start == pos && side < 0 || end == pos && side > 0)
+    return null
+
+  const word = text.slice(start, end);
+  const isCssClass = isInAttribute('class', text, start, end)
+  if (!isCssClass)
+    return null
+
+  return {
+    pos: start,
+    end,
+    above: true,
+    create(view) {
+      let dom = document.createElement("div")
+      dom.textContent = word
+      return {dom}
+    }
+  }
+})
+
+export default function cssPeek({theme = {}, config = {}} = {}) {
+  return [
+    wordHover,
+  ];
+}

--- a/src/css-peek.ts
+++ b/src/css-peek.ts
@@ -18,14 +18,22 @@ export default function cssPeek({src = [], cssContent = []} = {}) {
       }
     }
   }
+
+  /**
+   * Injects all CSS content into a disabled <style> tag to use
+   * the browser's parsing of the content and the built-in CSSStyleSheet in js
+   * @param className
+   */
   async function lookupCssClass(className: String) {
     const sheetTitle = 'cm-styles';
     let stylesheet = getStyleSheet(sheetTitle)
     if (!stylesheet) {
+      // if not already loaded on to page, grab content and load into <style> tag
       const cssContent = getCssContent()
       const el = document.createElement('style');
       el.innerHTML = cssContent;
-      el.setAttribute('disabled', 'disabled')
+      // disable it so it isn't applied. This flickers a little, so there could be a better way to do it.
+      el.setAttribute('onload', 'this.disabled=true')
       el.title = sheetTitle;
       document.body.appendChild(el);
       stylesheet = getStyleSheet(sheetTitle);
@@ -34,6 +42,7 @@ export default function cssPeek({src = [], cssContent = []} = {}) {
     if (!stylesheet)
       return null;
 
+    // find rules for this class name
     const styles = [...stylesheet.cssRules].filter((rule: CSSRule) => {
       return rule.selectorText == '.' + className;
     });

--- a/src/css-peek.ts
+++ b/src/css-peek.ts
@@ -2,14 +2,21 @@ import {hoverTooltip} from "@codemirror/tooltip"
 
 export default function cssPeek({src = [], cssContent = []} = {}) {
 
-  function getCssContent() {
+  async function getCssContent() {
     const content = cssContent || [];
 
-    //todo: fetch from files in `src` prop
-    //todo: cache files
+    // fetch from files in `src` prop
+    for (let srcFile of src) {
+      const response = await fetch(srcFile);
+      if (response && response.status == 200) {
+        const cssString = await response.text()
+        content.push(cssString)
+      }
+    }
 
     return content.join("\n");
   }
+
   function getStyleSheet(unique_title) {
     for(var i=0; i<document.styleSheets.length; i++) {
       var sheet = document.styleSheets[i];
@@ -29,7 +36,8 @@ export default function cssPeek({src = [], cssContent = []} = {}) {
     let stylesheet = getStyleSheet(sheetTitle)
     if (!stylesheet) {
       // if not already loaded on to page, grab content and load into <style> tag
-      const cssContent = getCssContent()
+      // todo: if css changes after this point, we need to find a way to refresh it
+      const cssContent = await getCssContent()
       const el = document.createElement('style');
       el.innerHTML = cssContent;
       // disable it so it isn't applied. This flickers a little, so there could be a better way to do it.


### PR DESCRIPTION
When hovering over a CSS class, a tooltip appears showing the styles that apply to that class.

Source CSS is configured via extension config and can either be raw CSS or references to CSS files to be loaded.

Caveat: Only matches styles that are exactly the class name. No inheritance is accounted for.