### PR TITLE
Auto-place cursor

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,7 +6,8 @@
   display: block;
   width: 100%;
 }`
-  const markup = `<h1>Hello world!</h1>`;
+  const markup = `<h1>Hello world!</h1>
+ul>li*3`;
 </script>
 <style>
   html, body, #app, main {

--- a/src/emmet-codemirror6-ext/index.ts
+++ b/src/emmet-codemirror6-ext/index.ts
@@ -1,9 +1,11 @@
 import {EditorView} from "@codemirror/basic-setup"
-import {StateField, EditorState} from "@codemirror/state"
+import {StateField, EditorState, EditorSelection, TransactionSpec, ChangeSpec} from "@codemirror/state"
 import {Tooltip, showTooltip} from "@codemirror/tooltip"
 import {keymap} from "@codemirror/view"
-import expand, { extract, Config } from 'emmet';
+import {expand} from './lib/emmet';
+import { extract, Config } from 'emmet';
 import {syntaxInfo} from './lib/syntax'
+import {getSelectionsFromSnippet, tabStopEnd, tabStopStart} from './lib/utils'
 
 export interface EmmetExt {
   theme: Object,
@@ -69,6 +71,43 @@ export default function emmetExt(extConfig : EmmetExt) {
   }
 
   /**
+   * Search for next tab stop start/end to get the next range
+   * to move the cursor to
+   * @param {EditorState} state
+   * @param {number} start - index to start searching from
+   */
+  function findNextTabStop(state: EditorState, start: number) {
+    const doc = state.doc.toString();
+    const nextTabStopStart = doc.indexOf(tabStopStart, start);
+    const from = nextTabStopStart;
+    if (nextTabStopStart > -1) {
+      let to;
+      const nextEnd = doc.indexOf(tabStopEnd, nextTabStopStart + 1);
+      const nextStart = doc.indexOf(tabStopStart, nextTabStopStart + 1);
+
+      if (nextEnd == -1) {
+        to = nextTabStopStart + 1; // just this single tabStopStart
+      } else if (nextStart == -1) {
+        to = nextEnd + 1 // select through next tabStopEnd
+      } else {
+        to = Math.min(nextStart, nextEnd);
+      }
+      to = to === -1 ? nextTabStopStart + 1 : to;
+
+      let placeholder = '';
+      if (to - from > 2) {
+        placeholder = state.doc.sliceString(from + 1, to - 1);
+      }
+      return {
+        from: nextTabStopStart,
+        to,
+        placeholder,
+      }
+    }
+    return null;
+  }
+
+  /**
    * Attempt to get a valid Emmet abbreviation from the current document selection
    * @param {EditorState} state
    * @returns {{start: number, end: number, abbreviation: string}|null}
@@ -120,7 +159,7 @@ export default function emmetExt(extConfig : EmmetExt) {
 
     return false;
   }
-  
+
   const cursorTooltipField = StateField.define<readonly Tooltip[]>({
     create: getCursorTooltips,
 
@@ -170,20 +209,54 @@ export default function emmetExt(extConfig : EmmetExt) {
     keymap.of([{
       key: "Tab",
       run: (view: EditorView) => {
-        const extraction = getEmmetAbbreviation(view.viewState.state);
+        const extraction = getEmmetAbbreviation(view.state);
         if (extraction) {
           const {abbreviation, start, end} = extraction
-          const expanded = expand(abbreviation, config)
-          view.dispatch({
+
+          const snippet = expand(abbreviation, config) as string;
+          const snippetPayload = getSelectionsFromSnippet(snippet);
+          const transaction = {
             changes: {
               from: start,
               to: end,
-              insert: expanded
-            }
-          })
+              insert: snippet
+            } as ChangeSpec
+          } as TransactionSpec;
+
+          // position cursor at first position in snippet
+          if (snippetPayload.ranges && snippetPayload.ranges.length) {
+            const range = snippetPayload.ranges[0];
+
+            // replace tab stop start/end characters of first selection
+            const placeholder = range[1] - range[0] > 2 ? view.state.doc.sliceString(range[0] + 1, range[1] - 1) : "";
+            const rangeStart = start + range[0];
+            transaction.selection = EditorSelection.range(rangeStart, rangeStart + placeholder.length);
+            transaction.changes.insert = snippet.slice(0, range[0]) +
+                placeholder +
+                snippet.slice(range[1]) +
+                tabStopStart;
+          }
+          view.dispatch(transaction)
           return true
         }
-        return false
+
+        // if there is an upcoming tabstop, move cursor to it
+        const { from } = view.state.selection.main
+        const nextRange = findNextTabStop(view.state, from);
+        if (nextRange) {
+          // replace tab stop start/end characters of next selection
+          view.dispatch({
+            changes: {
+              from: nextRange.from,
+              to: nextRange.to,
+              insert: nextRange.placeholder,
+            },
+            selection: EditorSelection.range(nextRange.from, nextRange.from + nextRange.placeholder.length),
+          });
+          return true;
+        }
+
+        return false;
       }
     }]),
   ];

--- a/src/emmet-codemirror6-ext/lib/emmet.ts
+++ b/src/emmet-codemirror6-ext/lib/emmet.ts
@@ -1,0 +1,39 @@
+import expandAbbreviation, { extract as extractAbbreviation, UserConfig, AbbreviationContext, ExtractedAbbreviation, Options, ExtractOptions, resolveConfig, MarkupAbbreviation, StylesheetAbbreviation, SyntaxType } from 'emmet';
+import match, { balancedInward, balancedOutward } from '@emmetio/html-matcher';
+import { balancedInward as cssBalancedInward, balancedOutward as cssBalancedOutward } from '@emmetio/css-matcher';
+import { selectItemCSS, selectItemHTML, TextRange } from '@emmetio/action-utils';
+import evaluate, { extract as extractMath, ExtractOptions as MathExtractOptions } from '@emmetio/math-expression';
+import { isXML, syntaxInfo, getMarkupAbbreviationContext, getStylesheetAbbreviationContext } from './syntax';
+import { getContent, isQuotedString } from './utils';
+import getEmmetConfig from './config';
+import getOutputOptions, { field } from './output';
+
+/**
+ * Cache for storing internal Emmet data.
+ * TODO reset whenever user settings are changed
+ */
+let cache = {};
+
+export const JSX_PREFIX = '<';
+
+/**
+ * Expands given abbreviation into code snippet
+ */
+export function expand(abbr: string | MarkupAbbreviation | StylesheetAbbreviation, config?: UserConfig) {
+    let opt: UserConfig = { cache };
+    const outputOpt: Partial<Options> = {
+        'output.field': field(),
+        'output.format': !config || !config['inline'],
+    };
+
+    if (config) {
+        Object.assign(opt, config);
+        if (config.options) {
+            Object.assign(outputOpt, config.options);
+        }
+    }
+
+    opt.options = outputOpt;
+
+    return expandAbbreviation(abbr as string, opt);
+}

--- a/src/emmet-codemirror6-ext/lib/output.ts
+++ b/src/emmet-codemirror6-ext/lib/output.ts
@@ -1,0 +1,38 @@
+import { tabStopStart, tabStopEnd } from './utils';
+
+/**
+ * Produces tabstop for CodeMirror editor
+ */
+export function field() {
+    let handled = -1;
+    return (index: number, placeholder: string) => {
+        if (handled === -1 || handled === index - 1) {
+            handled = index;
+            return placeholder
+                ? tabStopStart + placeholder + tabStopEnd
+                : tabStopStart;
+        }
+
+        return placeholder || '';
+    }
+}
+
+/**
+ * Returns indentation of given line
+ */
+export function lineIndent(editor: CodeMirror.Editor, line: number): string {
+    const lineStr = editor.getLine(line);
+    const indent = lineStr.match(/^\s+/);
+    return indent ? indent[0] : '';
+}
+
+/**
+ * Returns token used for single indentation in given editor
+ */
+export function getIndentation(editor: CodeMirror.Editor): string {
+    if (!editor.getOption('indentWithTabs')) {
+        return ' '.repeat(editor.getOption('indentUnit') || 0);
+    }
+
+    return '\t';
+}

--- a/src/emmet-codemirror6-ext/lib/utils.ts
+++ b/src/emmet-codemirror6-ext/lib/utils.ts
@@ -287,7 +287,7 @@ export function getInternalState(editor: CodeMirror.Editor): EmmetState {
 /**
  * Finds and collects selections ranges from given snippet
  */
-function getSelectionsFromSnippet(snippet: string, base = 0): { ranges: TextRange[], snippet: string } {
+export function getSelectionsFromSnippet(snippet: string, base = 0): { ranges: TextRange[], snippet: string } {
     // Find and collect selection ranges from snippet
     const ranges: TextRange[] = [];
     let result = '';
@@ -303,7 +303,7 @@ function getSelectionsFromSnippet(snippet: string, base = 0): { ranges: TextRang
             offset = i;
 
             if (ch === tabStopStart) {
-                sel = [base + result.length, base + result.length];
+                sel = [base + result.length, base + result.length + 1];
                 ranges.push(sel);
             } else if (sel) {
                 sel[1] = base + result.length;


### PR DESCRIPTION
Should allow you to tab through all the positions that emmet determines are places in the resulting snippet that the user should go to and/or edit.